### PR TITLE
Pin Claude Code OAuth loopback port to 8765

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,7 +125,18 @@ Use the **Clifton plugin** (OAuth, no key). It installs `clifton_ask` **plus** t
 
 The first time you ask a question, Claude Code opens a browser for Clifton sign-in. Then skip to **Your first question** below.
 
-Prefer an API key (no plugin, no skill)? Create one at **Settings → API keys** in the console, then:
+> **OAuth requires the fixed callback port `8765`.** Clifton sign-in only accepts the exact redirect `http://localhost:8765/callback`; a random port is rejected. The plugin ships `oauth.callbackPort: 8765` in its config to pin this. After installing and restarting Claude Code, confirm it took with `claude mcp get clifton` — the output should show `OAuth: callback_port 8765`. If it shows a different or random port, use the manual command below instead.
+
+**Recommended OAuth path (explicit, no skill):** add the server yourself with the port pinned. This is the most reliable way to get OAuth working:
+
+```bash
+claude mcp add --transport http --callback-port 8765 \
+  clifton https://ai.cliftonapi.com/v1/mcp
+```
+
+Then run `/mcp` and choose **clifton** to sign in. The `--callback-port 8765` flag is required — without it Claude Code picks a random port that Clifton's sign-in rejects.
+
+Prefer an **API key** (no plugin, no skill, no browser)? Create one at **Settings → API keys** in the console, then:
 
 ```bash
 export CLIFTON_API_KEY="paste-your-key-here"
@@ -133,9 +144,9 @@ claude mcp add --transport http clifton https://ai.cliftonapi.com/v1/mcp \
   --header "X-API-Key: $CLIFTON_API_KEY"
 ```
 
-Verify either way: ask *"What tools does Clifton provide?"* — the response lists `clifton_ask`.
+Verify any path: ask *"What tools does Clifton provide?"* — the response lists `clifton_ask`.
 
-> Reference: [Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp) — plugin install, `claude mcp add`, OAuth via `/mcp`.
+> Reference: [Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp) — plugin install, `claude mcp add`, `--callback-port`, OAuth via `/mcp`.
 
 ## Cursor
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -8,6 +8,21 @@ Checks for common MCP setup failures. For protocol-level errors, see the **Troub
 
 The OAuth sign-in handshake between the host and Clifton didn't complete. Confirm the connector URL is exactly `https://ai.cliftonapi.com/v1/mcp` and retry — this is sometimes transient. If it persists, it's more likely a Clifton-side issue than your setup: contact [support](SUPPORT.md) with the host you're using and the reference id shown in the error (e.g. `ofid_…`).
 
+### Claude Code OAuth fails with `redirect_uri not permitted` / `redirect_mismatch`
+
+Claude Code's loopback callback port didn't match the one Clifton's sign-in expects. Clifton requires the exact redirect `http://localhost:8765/callback`; by default Claude Code picks a random port (you'll see something like `http://localhost:61674/callback` in the browser URL), which is rejected.
+
+- **Plugin path:** the plugin ships a pinned port. Confirm it applied with `claude mcp get clifton` — it should show `OAuth: callback_port 8765`. If it doesn't (or shows a random port), use the manual command below instead of the plugin's server.
+- **Manual `claude mcp add` path:** you added the server without the fixed port. Remove and re-add it with the flag, then re-authenticate:
+
+  ```bash
+  claude mcp remove clifton
+  claude mcp add --transport http --callback-port 8765 \
+    clifton https://ai.cliftonapi.com/v1/mcp
+  ```
+
+  Run `/mcp` to sign in. A random port in the browser URL means the port wasn't pinned.
+
 ### Tool call returns `401 Unauthorized`
 
 The API key is invalid, or the OAuth session expired. Create a new key in the [Clifton console](https://console.cliftonapi.com), or re-authenticate through the host's MCP connection flow.

--- a/plugins/clifton-mcp/.mcp.json
+++ b/plugins/clifton-mcp/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "clifton": {
       "type": "http",
-      "url": "https://ai.cliftonapi.com/v1/mcp"
+      "url": "https://ai.cliftonapi.com/v1/mcp",
+      "oauth": {
+        "callbackPort": 8765
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Claude Code OAuth: pin the loopback callback port to 8765 (`oauth.callbackPort` in the plugin's `.mcp.json`), document the manual `claude mcp add --callback-port 8765` path in INSTALL.md, and add a TROUBLESHOOTING entry for `redirect_mismatch`.

Agents MCP guide split out to #2 (different release gate).

## Gate

Stays **draft** until the prod deploys land (Cognito callbacks #8562, CliffyRouter with the DCR shim #8552) and the plugin OAuth pass-through is verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)