### PR TITLE
Add Agents MCP guide (AGENT-TOOLS.md)

### DIFF
--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -16,7 +16,7 @@ Authentication ([API.md → Authentication](API.md#authentication)) differs by t
 - **`clifton_create_agent` requires OAuth sign-in.** It is not available to API-key callers — the server omits it from their tool list. Creation acts as a specific user, and an org-scoped API key has no user identity.
 - **The three read tools accept either** OAuth or an `X-API-Key` header.
 
-The canonical schemas live at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`.
+The read-tool schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. `clifton_create_agent` is OAuth-only, so its schema appears in authenticated `tools/list` after sign-in.
 
 ---
 

--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -11,7 +11,12 @@ Four tools:
 | `clifton_list_agent_reports` | List reports your agents have generated |
 | `clifton_get_agent_report` | Fetch one report's content |
 
-Authentication is the same as `clifton_ask`: OAuth sign-in or an `X-API-Key` header ([API.md → Authentication](API.md#authentication)). The canonical schemas live at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`.
+Authentication ([API.md → Authentication](API.md#authentication)) differs by tool:
+
+- **`clifton_create_agent` requires OAuth sign-in.** It is not available to API-key callers — the server omits it from their tool list. Creation acts as a specific user, and an org-scoped API key has no user identity.
+- **The three read tools accept either** OAuth or an `X-API-Key` header.
+
+The canonical schemas live at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`.
 
 ---
 
@@ -49,7 +54,7 @@ Optional. If you omit it, Clifton confirms the output type during the preview. S
 
 ### Agent limit
 
-Organizations have a cap on concurrently **enabled** agents. If creation would exceed it, the agent is saved as **paused** instead, and the response is `status: "error"` with a `workflow_limit_exceeded` block carrying your `limit` and current `active_count`. Pause or delete an agent in the [console](https://console.cliftonapi.com), then resume the new one — nothing is lost.
+Organizations have a cap on concurrently **enabled** agents. If creation would exceed it, the agent is saved with status `disabled` (the console calls this *paused*) instead, and the response is `status: "error"` with a `workflow_limit_exceeded` block carrying your `limit` and current `active_count`. Pause or delete an agent in the [console](https://console.cliftonapi.com), then resume the new one — nothing is lost.
 
 ### Timeouts
 
@@ -72,7 +77,7 @@ Cross-organization reads are rejected.
 
 ### `clifton_list_agents`
 
-Returns your agents, newest first: name, status (enabled/paused), schedule, and console link. Paginated with `limit` (default 10, max 1000) and `offset`.
+Returns your agents, newest first, with their `status` — one of `enabled`, `disabled` (shown as *paused* in the console), `creating`, `error`, or `awaiting_user_confirmation` — plus prompts, recipients, and report counts. Filter with `status` or `tags`. Paginated with `limit` (default 10, max 1000) and `offset`.
 
 ### `clifton_list_agent_reports`
 

--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -16,7 +16,7 @@ Authentication ([API.md → Authentication](API.md#authentication)) differs by t
 - **`clifton_create_agent` requires OAuth sign-in.** It is not available to API-key callers — the server omits it from their tool list. Creation acts as a specific user, and an org-scoped API key has no user identity.
 - **The three read tools accept either** OAuth or an `X-API-Key` header.
 
-The read-tool schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. `clifton_create_agent` is OAuth-only, so its schema appears in authenticated `tools/list` after sign-in.
+The read-tool schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. `clifton_create_agent` is OAuth-only, so its schema appears in authenticated `tools/list` after sign-in. Don't see these tools in your host? Reconnect the Clifton connection — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#your-host-shows-fewer-or-older-clifton-tools-than-expected-or-rejects-a-tool-argument).
 
 ---
 

--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -1,0 +1,99 @@
+# Clifton Agents over MCP
+
+Create and read **Clifton agents** — standing monitors that watch markets, filings, transcripts, and news for a condition you describe, then generate a report when it fires — directly from an MCP host (Claude Code, Claude Desktop, Cursor, or any client connected per [INSTALL.md](INSTALL.md)).
+
+Four tools:
+
+| Tool | What it does |
+|---|---|
+| `clifton_create_agent` | Multi-turn conversation that defines and enables a new agent |
+| `clifton_list_agents` | List your agents (name, status, schedule) |
+| `clifton_list_agent_reports` | List reports your agents have generated |
+| `clifton_get_agent_report` | Fetch one report's content |
+
+Authentication is the same as `clifton_ask`: OAuth sign-in or an `X-API-Key` header ([API.md → Authentication](API.md#authentication)). The canonical schemas live at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`.
+
+---
+
+## Creating an agent
+
+`clifton_create_agent` is conversational. Describe what you want watched; Clifton asks clarifying questions, shows a preview, and commits the agent when you confirm.
+
+```text
+You: Create an agent that alerts me when any S&P 500 bank announces a CEO change.
+Clifton: (clarifying question) Should this cover interim appointments, or only permanent successions?
+You: Only permanent.
+Clifton: (preview) … Confirm to enable.
+You: Confirm.
+Clifton: Agent enabled — view it at <agent_url>.
+```
+
+Each response carries a `status`:
+
+| `status` | Meaning |
+|---|---|
+| `creating` | Clifton asked a clarifying question or showed a preview — reply on the same `session_id` to continue |
+| `enabled` | The agent is committed and live; `workflow_id` and `agent_url` are set |
+| `error` | Preflight, quota, or agent-limit failure; `error_message` explains |
+
+Pass `session_id` from each response into your next call. Hosts do this automatically when you just keep talking.
+
+### Choosing the output type: `output_mode`
+
+| Value | The agent produces |
+|---|---|
+| `chat` | A written research report or alert |
+| `models` | A financial model (spreadsheet) it builds or maintains |
+
+Optional. If you omit it, Clifton confirms the output type during the preview. Set it explicitly when the request is unambiguous ("maintain a DCF for NVDA" → `models`).
+
+### Agent limit
+
+Organizations have a cap on concurrently **enabled** agents. If creation would exceed it, the agent is saved as **paused** instead, and the response is `status: "error"` with a `workflow_limit_exceeded` block carrying your `limit` and current `active_count`. Pause or delete an agent in the [console](https://console.cliftonapi.com), then resume the new one — nothing is lost.
+
+### Timeouts
+
+Creation turns are slower than `clifton_ask` — the commit turn generates and validates the agent and can take a couple of minutes. If your host enforces a shorter tool timeout and a turn is cut off, call again with the same `session_id`; the conversation resumes where it left off.
+
+### Attachments
+
+File attachments from the MCP host are **not** supported. The `attachments` field accepts Clifton Data Vault document ids only (files already uploaded via the console). To ground an agent in specific data, reference it in the message or upload the file to your Data Vault first.
+
+---
+
+## Reading agents and reports
+
+### Who you read as: `owner_email`
+
+- **OAuth callers** (signed in): `owner_email` is optional and defaults to you. You may pass another member of your organization to read their agents.
+- **API-key callers** (org-scoped key, no user identity): `owner_email` is required and must belong to the key's organization.
+
+Cross-organization reads are rejected.
+
+### `clifton_list_agents`
+
+Returns your agents, newest first: name, status (enabled/paused), schedule, and console link. Paginated with `limit` (default 10, max 1000) and `offset`.
+
+### `clifton_list_agent_reports`
+
+Returns report summaries, newest first: agent, fired time, outcome, and console link. Filter to one agent with `agent_id`. Same `limit`/`offset` pagination.
+
+### `clifton_get_agent_report`
+
+Fetches one report by id. The shape depends on the agent's output type and the run's outcome:
+
+| Report | You get |
+|---|---|
+| Generated, `chat` | The full report as markdown, plus a console link |
+| Generated, `models` | A time-limited download link for the spreadsheet, plus a console link |
+| Not generated (rate-limited / validation-failed) | A `reason` explaining why no report was produced |
+
+Every report includes a supporting-evidence summary: what the agent matched, with source links and match confidence.
+
+---
+
+## See also
+
+- [API.md](API.md) — endpoint, authentication, full tool reference
+- [INSTALL.md](INSTALL.md) — per-host setup, including the Claude Code OAuth callback port
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — common failures

--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -68,6 +68,8 @@ File attachments from the MCP host are **not** supported. The `attachments` fiel
 
 ## Reading agents and reports
 
+Read calls count toward your organization's MCP rate limits (the same per-org caps as other Clifton MCP tools); they do not consume chat quota.
+
 ### Who you read as: `owner_email`
 
 - **OAuth callers** (signed in): `owner_email` is optional and defaults to you. You may pass another member of your organization to read their agents.

--- a/API.md
+++ b/API.md
@@ -139,7 +139,7 @@ Four tools for creating and reading Clifton agents (standing monitors that gener
 
 | Tool | Summary | Key input fields |
 |---|---|---|
-| `clifton_create_agent` | Multi-turn agent creation; commits on your confirmation | `message` (required), `session_id`, `output_mode` (`chat` \| `models`) |
+| `clifton_create_agent` | Multi-turn agent creation; commits on your confirmation. **OAuth only** — not offered to API-key callers | `message` (required), `session_id`, `output_mode` (`chat` \| `models`) |
 | `clifton_list_agents` | List agents, newest first | `owner_email`*, `limit` (default 10), `offset` |
 | `clifton_list_agent_reports` | List report summaries, newest first | `owner_email`*, `agent_id`, `limit` (default 10), `offset` |
 | `clifton_get_agent_report` | One report: markdown (chat), spreadsheet link (models), or a no-report `reason` | report id, `owner_email`* |

--- a/API.md
+++ b/API.md
@@ -14,7 +14,7 @@ Technical reference for connecting an MCP host to Clifton. Use this for Claude C
 - **Protocol:** JSON-RPC 2.0 single-request per POST. Batch arrays are **not** supported.
 - **Region:** us-east-2.
 
-The pinned `tools/list` snapshot is published at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. Fetch it before setup if your client validates tool schemas ahead of time.
+The public `tools/list` snapshot is published at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. OAuth-only tools are returned by authenticated `tools/list` after sign-in.
 
 ---
 
@@ -106,7 +106,7 @@ http_headers = { "X-API-Key" = "paste-your-key-here" }
 
 ## Available tools
 
-> **Canonical contract:** `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. Fetch this URL for the current tool names, descriptions, JSON Schemas, and annotations. The summary below is non-authoritative and may lag the live contract.
+> **Tool contract:** `https://ai.cliftonapi.com/.well-known/mcp-tools.json` lists public tools. OAuth-only tools, including `clifton_create_agent`, are returned by authenticated `tools/list` after sign-in. The summary below is non-authoritative and may lag the live contract.
 
 ### `clifton_ask` *(read-only)*
 
@@ -179,7 +179,7 @@ For unresolved issues, include the `X-Request-Id` from the failing response and 
 
 ## Further reading
 
-- Pinned tool contract: `https://ai.cliftonapi.com/.well-known/mcp-tools.json`
+- Public tool contract: `https://ai.cliftonapi.com/.well-known/mcp-tools.json`
 - OAuth protected-resource metadata: `https://ai.cliftonapi.com/.well-known/oauth-protected-resource`
 - Customer setup walkthrough: [INSTALL.md](INSTALL.md)
 - Common host issues: [TROUBLESHOOTING.md](TROUBLESHOOTING.md)

--- a/API.md
+++ b/API.md
@@ -133,6 +133,19 @@ Questions about markets and finance — public companies, tickers, sectors, inde
 | `structuredContent.session_id` | string \| null | Server-acknowledged session id. Echo to continue. |
 | `structuredContent.request_id` | string | Present on errors. Identifies the call in Clifton's logs; quote it when contacting support. |
 
+### Agent tools
+
+Four tools for creating and reading Clifton agents (standing monitors that generate reports when their condition fires). Full guide with examples, the agent limit, `output_mode`, and `owner_email` semantics: [AGENT-TOOLS.md](AGENT-TOOLS.md).
+
+| Tool | Summary | Key input fields |
+|---|---|---|
+| `clifton_create_agent` | Multi-turn agent creation; commits on your confirmation | `message` (required), `session_id`, `output_mode` (`chat` \| `models`) |
+| `clifton_list_agents` | List agents, newest first | `owner_email`*, `limit` (default 10), `offset` |
+| `clifton_list_agent_reports` | List report summaries, newest first | `owner_email`*, `agent_id`, `limit` (default 10), `offset` |
+| `clifton_get_agent_report` | One report: markdown (chat), spreadsheet link (models), or a no-report `reason` | report id, `owner_email`* |
+
+\* `owner_email` defaults to the signed-in user for OAuth callers; required for API-key callers and must belong to the key's organization. Cross-organization reads are rejected.
+
 ---
 
 ## Operational Notes (Not Contract)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,7 @@ Public changes to the Clifton MCP tool surface.
 
 ## [Unreleased]
 
+- **Agent tools.** `clifton_create_agent` (OAuth sign-in required) creates a recurring Clifton agent through a multi-turn conversation, with optional `output_mode: chat | models`. Three read tools — `clifton_list_agents`, `clifton_list_agent_reports`, `clifton_get_agent_report` — list your agents and fetch their reports; available to both OAuth and API-key callers (API-key callers pass `owner_email`). Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
+- **OAuth sign-in for Claude Code.** The server accepts loopback redirect URIs and Clifton sign-in registers the fixed callback port `8765`; the plugin pins `oauth.callbackPort: 8765`. Manual setup: `claude mcp add --transport http --callback-port 8765 clifton https://ai.cliftonapi.com/v1/mcp`.
+- If a connected host doesn't show the new tools, reconnect it — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) (an app restart alone is not enough on Claude Desktop).
 - Initial public docs + Claude Code plugin (`clifton-mcp` v0.1.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Public changes to the Clifton MCP tool surface.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-10
+
 - **Agent tools.** `clifton_create_agent` (OAuth sign-in required) creates a recurring Clifton agent through a multi-turn conversation, with optional `output_mode: chat | models`. Three read tools — `clifton_list_agents`, `clifton_list_agent_reports`, `clifton_get_agent_report` — list your agents and fetch their reports; available to both OAuth and API-key callers (API-key callers pass `owner_email`). Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
-- **OAuth sign-in for Claude Code.** The server accepts loopback redirect URIs and Clifton sign-in registers the fixed callback port `8765`; the plugin pins `oauth.callbackPort: 8765`. Manual setup: `claude mcp add --transport http --callback-port 8765 clifton https://ai.cliftonapi.com/v1/mcp`.
+- **OAuth sign-in for Claude Code.** The server accepts loopback redirect URIs and Clifton sign-in registers the fixed callback port `8765`; the plugin pins `oauth.callbackPort: 8765` in its config. Manual setup: `claude mcp add --transport http --callback-port 8765 clifton https://ai.cliftonapi.com/v1/mcp`.
 - If a connected host doesn't show the new tools, reconnect it — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) (an app restart alone is not enough on Claude Desktop).
-- Initial public docs + Claude Code plugin (`clifton-mcp` v0.1.0).
+
+## [0.1.0]
+
+- Initial public docs + Claude Code plugin (`clifton-mcp`).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Config snippets live in [`examples/`](examples/).
 ## Tools
 
 - **`clifton_ask`** — answers markets & finance questions (equities, ETFs, crypto, bonds, options, macro) from filings, earnings transcripts, analyst expectations, market data, and news; returns citations.
+- **Agent tools** — `clifton_create_agent` creates a standing monitor through a short conversation (written reports or financial models); `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report` read your agents and their reports. Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
 
 Full tool reference, auth, and errors: [API.md](API.md).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/cliftonai/clifton-mcp/pulls)
 
-Clifton exposes one MCP tool, `clifton_ask`, for markets and finance research — public companies, ETFs, crypto, bonds, options, and macro data. It answers from SEC filings, earnings transcripts, analyst expectations, market data, and news, then cites the documents or data it used.
+Clifton exposes MCP tools for markets and finance research plus recurring agents. `clifton_ask` answers questions about public companies, ETFs, crypto, bonds, options, and macro data from SEC filings, earnings transcripts, analyst expectations, market data, and news, then cites the documents or data it used.
 
 ![Clifton answering a financial research question in Claude](assets/demo.gif)
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -31,12 +31,12 @@ The API key is invalid, or the OAuth session expired. Create a new key in the [C
 
 The question needed more time than the client-safe budget allows. The response includes a Clifton-console link — open it to continue the question there — or ask a narrower question. If you contact support, quote the `request_id` from the response.
 
-### A tool argument is rejected, or your host shows an option Clifton no longer has
+### Your host shows fewer or older Clifton tools than expected, or rejects a tool argument
 
-Your host cached an older copy of Clifton's tool list. When Clifton updates a tool (adds or removes an argument), the host keeps using its cached version until it reconnects — so it may keep sending an argument the server now rejects, or keep offering one that's gone. **Reconnect Clifton to refresh the tool list, then retry:**
+Your host cached an older copy of Clifton's tool list. When Clifton releases a new tool or updates an existing one, the host keeps using its cached version until it reconnects — newly released tools (such as the agent tools) won't appear, and a changed argument may be rejected or a removed one still offered. **Reconnect Clifton to refresh the tool list, then retry:**
 
 - **Claude Code:** run `/mcp`, reconnect Clifton — or restart Claude Code. (Plugin install: `/plugin uninstall clifton-mcp@clifton-mcp` then re-install also forces a clean fetch.)
-- **Claude Web / Desktop:** open **Connectors**, toggle Clifton **off and on** (or remove and re-add it).
+- **Claude Web / Desktop:** open **Connectors**, toggle Clifton **off and on** (or remove and re-add it). Restarting the app alone is **not** enough — the tool list is tied to the connector, not the app session.
 - **Cursor:** restart Cursor, or toggle the Clifton server off/on in **Settings → MCP**.
 - **Codex:** restart Codex.
 

--- a/plugins/clifton-mcp/.claude-plugin/plugin.json
+++ b/plugins/clifton-mcp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "clifton-mcp",
   "displayName": "Clifton MCP",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Source-linked financial research over MCP — SEC filings, transcripts, expectations, and market reactions.",
   "author": {
     "name": "Clifton Software, Inc.",


### PR DESCRIPTION
## Summary

Adds the public Agents MCP guide now that the agent tools are live in prod.

- **`AGENT-TOOLS.md`** documents `clifton_create_agent`, `output_mode: chat | models`, the enabled-agent limit, timeout recovery, Data Vault document-id attachments, and the three read tools.
- **`API.md`** adds the agent tools table and clarifies that `clifton_create_agent` is OAuth-only, so it appears in authenticated `tools/list` after sign-in.
- **`README.md`** now describes Clifton's finance Q&A and agent tools.

## Checks

- Prod MCP config includes `clifton_create_agent` and the three read tools.
- Prod `mcp_create_agent` feature gate is `['*']`.
- Local CI checks passed.
