### PR TITLE
docs: add MCP Data Vault file attachment flow

### DIFF
--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -16,7 +16,7 @@ Authentication ([API.md → Authentication](API.md#authentication)) differs by t
 - **`clifton_create_agent` requires OAuth sign-in.** It is not available to API-key callers — the server omits it from their tool list. Creation acts as a specific user, and an org-scoped API key has no user identity.
 - **The three read tools accept either** OAuth or an `X-API-Key` header.
 
-The read-tool schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. `clifton_create_agent` and `clifton_list_vault_files` are OAuth-only, so their schemas appear in authenticated `tools/list` after sign-in. Don't see these tools in your host? Reconnect the Clifton connection — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#your-host-shows-fewer-or-older-clifton-tools-than-expected-or-rejects-a-tool-argument).
+The public schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. Authenticated `tools/list` applies user and organization gates and is authoritative for the caller. If your host does not show these tools, reconnect the Clifton connection. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#your-host-shows-fewer-or-older-clifton-tools-than-expected-or-rejects-a-tool-argument).
 
 ---
 

--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -16,7 +16,7 @@ Authentication ([API.md → Authentication](API.md#authentication)) differs by t
 - **`clifton_create_agent` requires OAuth sign-in.** It is not available to API-key callers — the server omits it from their tool list. Creation acts as a specific user, and an org-scoped API key has no user identity.
 - **The three read tools accept either** OAuth or an `X-API-Key` header.
 
-The read-tool schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. `clifton_create_agent` is OAuth-only, so its schema appears in authenticated `tools/list` after sign-in. Don't see these tools in your host? Reconnect the Clifton connection — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#your-host-shows-fewer-or-older-clifton-tools-than-expected-or-rejects-a-tool-argument).
+The read-tool schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. `clifton_create_agent` and `clifton_list_vault_files` are OAuth-only, so their schemas appear in authenticated `tools/list` after sign-in. Don't see these tools in your host? Reconnect the Clifton connection — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#your-host-shows-fewer-or-older-clifton-tools-than-expected-or-rejects-a-tool-argument).
 
 ---
 
@@ -74,7 +74,7 @@ Creation turns are slower than `clifton_ask` — the commit turn generates and v
 
 ### Attachments
 
-File attachments from the MCP host are **not** supported. The `attachments` field accepts Clifton Data Vault document ids only (files already uploaded via the console). To ground an agent in specific data, reference it in the message or upload the file to your Data Vault first.
+File attachments from the MCP host are **not** supported. The `attachments` field accepts Clifton Data Vault file IDs only: files already uploaded via the console. Use `clifton_list_vault_files` to find IDs for files the signed-in user can access, then pass those IDs to `clifton_create_agent.attachments` for agent creation or `clifton_ask.attachments` for one-off analysis.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -106,7 +106,7 @@ http_headers = { "X-API-Key" = "paste-your-key-here" }
 
 ## Available tools
 
-> **Tool contract:** `https://ai.cliftonapi.com/.well-known/mcp-tools.json` lists public tools. OAuth-only tools, including `clifton_create_agent` and `clifton_list_vault_files`, are returned by authenticated `tools/list` after sign-in. The summary below is non-authoritative and may lag the live contract.
+> **Tool contract:** `https://ai.cliftonapi.com/.well-known/mcp-tools.json` lists public tools. Authenticated `tools/list` applies user and organization gates and is authoritative for the caller. The summary below is non-authoritative and may lag the live contract.
 
 ### `clifton_ask` *(read-only)*
 
@@ -133,11 +133,11 @@ Questions about markets and finance — public companies, tickers, sectors, inde
 | `structuredContent.session_id` | string \| null | Server-acknowledged session id. Echo to continue. |
 | `structuredContent.request_id` | string | Present on errors. Identifies the call in Clifton's logs; quote it when contacting support. |
 
-### `clifton_list_vault_files` *(read-only, OAuth only)*
+### `clifton_list_vault_files` *(read-only)*
 
-Find Clifton Data Vault files the signed-in user can access, then pass returned file IDs to `clifton_ask.attachments`.
+Find Clifton Data Vault files for an authorized owner, then pass returned file IDs to `clifton_ask.attachments`.
 
-API-key callers do not see this tool because Data Vault USER-scope files require a signed-in user identity.
+OAuth callers default to the signed-in user. API-key callers must pass an `owner_email` for a manager in the authenticated organization.
 
 **Input**
 
@@ -148,6 +148,7 @@ API-key callers do not see this tool because Data Vault USER-scope files require
 | `storage_class` | `EPHEMERAL` \| `DURABLE` | no | Optional storage class filter. |
 | `limit` | integer | no | Defaults to 50; maximum 1000. |
 | `offset` | integer | no | Zero-based pagination offset. |
+| `owner_email` | string | API key only | Vault owner. OAuth defaults to the signed-in user; API keys require an authorized manager email. |
 
 **Output**
 

--- a/API.md
+++ b/API.md
@@ -106,7 +106,7 @@ http_headers = { "X-API-Key" = "paste-your-key-here" }
 
 ## Available tools
 
-> **Tool contract:** `https://ai.cliftonapi.com/.well-known/mcp-tools.json` lists public tools. OAuth-only tools, including `clifton_create_agent`, are returned by authenticated `tools/list` after sign-in. The summary below is non-authoritative and may lag the live contract.
+> **Tool contract:** `https://ai.cliftonapi.com/.well-known/mcp-tools.json` lists public tools. OAuth-only tools, including `clifton_create_agent` and `clifton_list_vault_files`, are returned by authenticated `tools/list` after sign-in. The summary below is non-authoritative and may lag the live contract.
 
 ### `clifton_ask` *(read-only)*
 
@@ -120,7 +120,7 @@ Questions about markets and finance — public companies, tickers, sectors, inde
 | `session_id` | string | no | Echo back from a prior response to continue a conversation. |
 | `incognito` | boolean | no | Skip persistence. |
 | `data_sources` | string[] | no | Restrict retrieval to a subset of sources. |
-| `attachments` | string[] | no | Document IDs to include. |
+| `attachments` | string[] | no | Clifton Data Vault file IDs to include. Use `clifton_list_vault_files` to find accessible IDs. |
 | `context` | object | no | Host-supplied metadata. |
 
 **Output**
@@ -132,6 +132,32 @@ Questions about markets and finance — public companies, tickers, sectors, inde
 | `structuredContent.citations` | array | Parsed citation objects (`url`, `text`, `snippet`). |
 | `structuredContent.session_id` | string \| null | Server-acknowledged session id. Echo to continue. |
 | `structuredContent.request_id` | string | Present on errors. Identifies the call in Clifton's logs; quote it when contacting support. |
+
+### `clifton_list_vault_files` *(read-only, OAuth only)*
+
+Find Clifton Data Vault files the signed-in user can access, then pass returned file IDs to `clifton_ask.attachments`.
+
+API-key callers do not see this tool because Data Vault USER-scope files require a signed-in user identity.
+
+**Input**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `query` | string | no | Search by filename and indexed file content when available. Omit to browse folders. Max 100 characters. |
+| `folder_path` | string | no | Folder path to browse or constrain search. Defaults to `/`. |
+| `storage_class` | `EPHEMERAL` \| `DURABLE` | no | Optional storage class filter. |
+| `limit` | integer | no | Defaults to 50; maximum 1000. |
+| `offset` | integer | no | Zero-based pagination offset. |
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `files` | array | File metadata including `file_id`, filename, content type, size, scope, folder, and timestamps. |
+| `folders` | array | Immediate child folders when browsing. Empty when `query` is provided. |
+| `attachment_ids` | string[] | File IDs from `files[].file_id`; pass these to `clifton_ask.attachments`. |
+| `current_path` | string | Folder path used for the result. |
+| `pagination` | object | `limit`, `offset`, `total`, `count`, `has_more`. |
 
 ### Agent tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Public changes to the Clifton MCP tool surface.
 
 ## [Unreleased]
 
+- **Data Vault file discovery.** OAuth users can use `clifton_list_vault_files` to find Clifton Data Vault file IDs, then pass those IDs to `clifton_ask.attachments`.
+
 ## [0.1.2] - 2026-06-12
 
 - **Skill covers agents.** The `clifton-research` skill now triggers for agent flows — creating standing monitors (create/watch/alert/schedule) and reading agents and reports — and teaches hosts the creation loop: relay clarifying questions and previews, continue on the same `session_id`, never confirm on the user's behalf, and treat only `status: "enabled"` as created.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Public changes to the Clifton MCP tool surface.
 
 ## [Unreleased]
 
-- **Data Vault file discovery.** OAuth users can use `clifton_list_vault_files` to find Clifton Data Vault file IDs, then pass those IDs to `clifton_ask.attachments`.
+- **Data Vault file discovery.** OAuth and API-key callers can use `clifton_list_vault_files` to find authorized Clifton Data Vault file IDs, then pass those IDs to `clifton_ask.attachments`.
 
 ## [0.1.2] - 2026-06-12
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Connect Clifton over MCP
 
-Clifton's MCP server lets Claude, ChatGPT, and developer CLIs (Claude Code, Cursor, Codex) call `clifton_ask` for markets and finance questions — equities, ETFs, crypto, bonds, options, macro, SEC filings, and earnings. OAuth hosts can also list Clifton Data Vault files and attach them to an ask. Use it for questions like *"why is NVDA moving today?"* or *"summarize the model I uploaded to Data Vault."*
+Clifton's MCP server lets Claude, ChatGPT, and developer CLIs (Claude Code, Cursor, Codex) call `clifton_ask` for markets and finance questions. Connected hosts can also list authorized Clifton Data Vault files and attach them to an ask.
 
 OAuth hosts need the MCP URL. API-key hosts need the same URL plus an `X-API-Key` header.
 
@@ -33,7 +33,7 @@ You'll also need:
 | **Codex** (CLI) | API key + TOML snippet | ~ 2 min |
 | **Codex** (Desktop app) | API key + form fields | < 1 min |
 
-> **Tool vs. skill:** Every path connects `clifton_ask`. OAuth paths may also expose user-scoped tools such as `clifton_list_vault_files`. The **Claude Code plugin** also installs the `clifton-research` skill, which nudges Claude Code to use Clifton for finance questions. Connector and API-key paths add MCP tools only.
+> **Tool vs. skill:** Every path connects `clifton_ask`. OAuth and API-key paths may also expose `clifton_list_vault_files`. The **Claude Code plugin** installs the `clifton-research` skill, which routes finance questions to Clifton. Connector and API-key paths add MCP tools only.
 
 Use the section for your host. Most people want the first one.
 
@@ -91,7 +91,7 @@ Custom MCP apps in ChatGPT require **Developer mode**. OpenAI currently document
 - **Enterprise / Edu:** admins grant access; enabled users turn it on under **Settings → Apps → Advanced Settings**.
 - If you do not see **Apps → Create**, your workspace probably does not have Developer mode enabled.
 
-> Developer mode can enable apps with write actions. Clifton's current MCP tools are read-only, but enable Developer mode deliberately.
+> Developer mode can enable apps with write actions. Clifton includes agent-creation tools, so enable Developer mode deliberately.
 
 ### 2. Create the Clifton app
 
@@ -145,7 +145,7 @@ claude mcp add --transport http clifton https://ai.cliftonapi.com/v1/mcp \
   --header "X-API-Key: $CLIFTON_API_KEY"
 ```
 
-Verify any path: ask *"What tools does Clifton provide?"* — the response lists `clifton_ask`. OAuth connections may also list `clifton_list_vault_files`.
+Verify any path: ask *"What tools does Clifton provide?"* The response lists `clifton_ask`; eligible OAuth and API-key connections also list `clifton_list_vault_files`.
 
 > Reference: [Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp) — plugin install, `claude mcp add`, `--callback-port`, OAuth via `/mcp`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Connect Clifton over MCP
 
-Clifton's MCP server lets Claude, ChatGPT, and developer CLIs (Claude Code, Cursor, Codex) call `clifton_ask` for markets and finance questions — equities, ETFs, crypto, bonds, options, macro, SEC filings, and earnings. Use it for questions like *"why is NVDA moving today?"* or *"did AAPL add new risk factors in its latest 10-K?"*
+Clifton's MCP server lets Claude, ChatGPT, and developer CLIs (Claude Code, Cursor, Codex) call `clifton_ask` for markets and finance questions — equities, ETFs, crypto, bonds, options, macro, SEC filings, and earnings. OAuth hosts can also list Clifton Data Vault files and attach them to an ask. Use it for questions like *"why is NVDA moving today?"* or *"summarize the model I uploaded to Data Vault."*
 
 OAuth hosts need the MCP URL. API-key hosts need the same URL plus an `X-API-Key` header.
 
@@ -33,7 +33,7 @@ You'll also need:
 | **Codex** (CLI) | API key + TOML snippet | ~ 2 min |
 | **Codex** (Desktop app) | API key + form fields | < 1 min |
 
-> **Tool vs. skill:** Every path connects the same `clifton_ask` tool. The **Claude Code plugin** also installs the `clifton-research` skill, which nudges Claude Code to use Clifton for finance questions. Connector and API-key paths add the tool only.
+> **Tool vs. skill:** Every path connects `clifton_ask`. OAuth paths may also expose user-scoped tools such as `clifton_list_vault_files`. The **Claude Code plugin** also installs the `clifton-research` skill, which nudges Claude Code to use Clifton for finance questions. Connector and API-key paths add MCP tools only.
 
 Use the section for your host. Most people want the first one.
 
@@ -91,7 +91,7 @@ Custom MCP apps in ChatGPT require **Developer mode**. OpenAI currently document
 - **Enterprise / Edu:** admins grant access; enabled users turn it on under **Settings → Apps → Advanced Settings**.
 - If you do not see **Apps → Create**, your workspace probably does not have Developer mode enabled.
 
-> Developer mode can enable apps with write actions. Clifton currently exposes only the read-only `clifton_ask` tool, but enable Developer mode deliberately.
+> Developer mode can enable apps with write actions. Clifton's current MCP tools are read-only, but enable Developer mode deliberately.
 
 ### 2. Create the Clifton app
 
@@ -145,7 +145,7 @@ claude mcp add --transport http clifton https://ai.cliftonapi.com/v1/mcp \
   --header "X-API-Key: $CLIFTON_API_KEY"
 ```
 
-Verify any path: ask *"What tools does Clifton provide?"* — the response lists `clifton_ask`.
+Verify any path: ask *"What tools does Clifton provide?"* — the response lists `clifton_ask`. OAuth connections may also list `clifton_list_vault_files`.
 
 > Reference: [Connect Claude Code to tools via MCP](https://code.claude.com/docs/en/mcp) — plugin install, `claude mcp add`, `--callback-port`, OAuth via `/mcp`.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/cliftonai/clifton-mcp/pulls)
 
-Clifton exposes MCP tools for markets and finance research plus recurring agents. `clifton_ask` answers questions about public companies, ETFs, crypto, bonds, options, and macro data from SEC filings, earnings transcripts, analyst expectations, market data, and news, then cites the documents or data it used.
+Clifton exposes MCP tools for markets and finance research, Data Vault file discovery, and recurring agents. `clifton_ask` answers questions about public companies, ETFs, crypto, bonds, options, and macro data from SEC filings, earnings transcripts, analyst expectations, market data, news, and attached Clifton Data Vault files, then cites the documents or data it used.
 
 ![Clifton answering a financial research question in Claude](assets/demo.gif)
 
@@ -52,6 +52,7 @@ Config snippets live in [`examples/`](examples/).
 ## Tools
 
 - **`clifton_ask`** — answers markets & finance questions (equities, ETFs, crypto, bonds, options, macro) from filings, earnings transcripts, analyst expectations, market data, and news; returns citations.
+- **`clifton_list_vault_files`** — OAuth-only file discovery for Clifton Data Vault. Use returned file IDs in `clifton_ask.attachments`.
 - **Agent tools** — `clifton_create_agent` creates a standing monitor through a short conversation (written reports or financial models); `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report` read your agents and their reports. Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
 
 Full tool reference, auth, and errors: [API.md](API.md).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Config snippets live in [`examples/`](examples/).
 ## Tools
 
 - **`clifton_ask`** — answers markets & finance questions (equities, ETFs, crypto, bonds, options, macro) from filings, earnings transcripts, analyst expectations, market data, and news; returns citations.
-- **`clifton_list_vault_files`** — OAuth-only file discovery for Clifton Data Vault. Use returned file IDs in `clifton_ask.attachments`.
+- **`clifton_list_vault_files`:** OAuth and API-key file discovery for Clifton Data Vault. Use returned file IDs in `clifton_ask.attachments`.
 - **Agent tools** — `clifton_create_agent` creates a standing monitor through a short conversation (written reports or financial models); `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report` read your agents and their reports. Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
 
 Full tool reference, auth, and errors: [API.md](API.md).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ The question needed more time than the client-safe budget allows. The response i
 
 ### Your host shows fewer or older Clifton tools than expected, or rejects a tool argument
 
-Your host cached an older copy of Clifton's tool list. When Clifton releases a new tool or updates an existing one, the host keeps using its cached version until it reconnects — newly released tools (such as the agent tools) won't appear, and a changed argument may be rejected or a removed one still offered. **Reconnect Clifton to refresh the tool list, then retry:**
+Your host cached an older copy of Clifton's tool list. When Clifton releases a new tool or updates an existing one, the host keeps using its cached version until it reconnects — newly released tools such as `clifton_list_vault_files` or the agent tools won't appear, and a changed argument may be rejected or a removed one still offered. **Reconnect Clifton to refresh the tool list, then retry:**
 
 - **Claude Code:** run `/mcp`, reconnect Clifton — or restart Claude Code. (Plugin install: `/plugin uninstall clifton-mcp@clifton-mcp` then re-install also forces a clean fetch.)
 - **Claude Web / Desktop:** open **Connectors**, toggle Clifton **off and on** (or remove and re-add it). Restarting the app alone is **not** enough — the tool list is tied to the connector, not the app session.

--- a/plugins/clifton-mcp/skills/clifton-research/SKILL.md
+++ b/plugins/clifton-mcp/skills/clifton-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clifton-research
-description: Use Clifton for any markets or finance question — stocks, ETFs, crypto, bonds, options, macro and economic data, SEC filings, earnings, transcripts, analyst ratings, screening, and cross-company comparisons — and for Clifton agents, when the user wants to create, monitor, watch, alert on, or schedule a standing market monitor, or to list their agents and read agent reports. Calls clifton_ask and the clifton agent tools on the bundled clifton MCP server.
+description: Use Clifton for any markets or finance question — stocks, ETFs, crypto, bonds, options, macro and economic data, SEC filings, earnings, transcripts, analyst ratings, screening, cross-company comparisons, and uploaded Clifton Data Vault files — and for Clifton agents, when the user wants to create, monitor, watch, alert on, or schedule a standing market monitor, or to list their agents and read agent reports. Calls clifton_ask, clifton_list_vault_files, and the clifton agent tools on the bundled clifton MCP server.
 ---
 
 # Clifton Research & Agents
@@ -32,6 +32,10 @@ When in doubt and the question is about money, markets, or a company, call Clift
 ## Multi-turn
 
 To continue a topic across calls, pass the `session_id` from the previous response back in the next `clifton_ask` call.
+
+## Data Vault files
+
+When the user asks about an uploaded file, model, deck, spreadsheet, or other Clifton Data Vault item, call `clifton_list_vault_files` first to find accessible file IDs. Then call `clifton_ask` with those IDs in `attachments`. Do not claim a host-side file is attached unless it already exists in Clifton Data Vault or the user uploads it there first.
 
 ## Agents — standing monitors
 


### PR DESCRIPTION
## Summary

- Document clifton_list_vault_files for OAuth and API-key callers.
- Explain owner_email, folder browsing, search, pagination, and attachment IDs.
- Update install, troubleshooting, README, changelog, and bundled-skill guidance.

## Production verification

- [cliftonai/src#9767](https://github.com/cliftonai/src/pull/9767) added API-key owner authorization.
- Production enables clifton_list_vault_files for OAuth and API-key callers.
- Production OAuth and API-key calls passed on July 14, 2026.
- Missing owner_email on an API-key call returned owner_email_required.

## Validation

- Repository manifest and documentation checks passed.
- git diff --check passed.
- No server or runtime configuration changes.