### PR TITLE
docs: add MCP agent deletion contract

### DIFF
--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -7,7 +7,7 @@ Five tools:
 | Tool | What it does |
 |---|---|
 | `clifton_create_agent` | Multi-turn conversation that defines and enables a new agent |
-| `clifton_delete_agent` | Delete one agent owned by the signed-in user |
+| `clifton_delete_agent` | Delete one agent owned by an authorized user |
 | `clifton_list_agents` | List your agents (name, status, schedule) |
 | `clifton_list_agent_reports` | List reports your agents have generated |
 | `clifton_get_agent_report` | Fetch one report's content |
@@ -15,7 +15,7 @@ Five tools:
 Authentication ([API.md → Authentication](API.md#authentication)) differs by tool:
 
 - **`clifton_create_agent` accepts OAuth and approved API-key callers.** OAuth callers default to the signed-in user. API-key callers see the tool only when Clifton has enabled API-key creation for their organization; they must pass an `owner_email` for a manager in that organization.
-- **`clifton_delete_agent` requires OAuth sign-in.** The server omits it from API-key tool lists because deletion acts as the signed-in user.
+- **`clifton_delete_agent` accepts OAuth and API keys.** OAuth callers default to the signed-in user. API-key callers must pass an `owner_email` for a manager in their organization.
 - **The three read tools accept either** OAuth or an `X-API-Key` header.
 
 The public schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. Authenticated `tools/list` applies user and organization gates and is authoritative for the caller. If your host does not show these tools, reconnect the Clifton connection. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#your-host-shows-fewer-or-older-clifton-tools-than-expected-or-rejects-a-tool-argument).
@@ -82,7 +82,7 @@ File attachments from the MCP host are **not** supported. The `attachments` fiel
 
 ## Deleting an agent
 
-`clifton_delete_agent` accepts one `agent_id`. Use `clifton_list_agents` first when the user names an agent but does not provide its id.
+`clifton_delete_agent` accepts an `agent_id` and optional `owner_email`. OAuth callers default to the signed-in user. API-key callers must pass an authorized manager's email. Use `clifton_list_agents` first when the user names an agent but does not provide its id.
 
 - Call deletion only after the user clearly asks to delete or remove the agent.
 - If several agents match the request, show the matches and ask the user to choose. Do not guess.

--- a/AGENT-TOOLS.md
+++ b/AGENT-TOOLS.md
@@ -1,19 +1,21 @@
 # Clifton Agents over MCP
 
-Create and read **Clifton agents** — standing monitors that watch markets, filings, transcripts, and news for a condition you describe, then generate a report when it fires — directly from an MCP host (Claude Code, Claude Desktop, Cursor, or any client connected per [INSTALL.md](INSTALL.md)).
+Use an MCP host to create, delete, and read **Clifton agents**. These standing monitors watch markets, filings, transcripts, and news, then generate a report when a condition fires. Supported hosts include Claude Code, Claude Desktop, Cursor, and any client connected per [INSTALL.md](INSTALL.md).
 
-Four tools:
+Five tools:
 
 | Tool | What it does |
 |---|---|
 | `clifton_create_agent` | Multi-turn conversation that defines and enables a new agent |
+| `clifton_delete_agent` | Delete one agent owned by the signed-in user |
 | `clifton_list_agents` | List your agents (name, status, schedule) |
 | `clifton_list_agent_reports` | List reports your agents have generated |
 | `clifton_get_agent_report` | Fetch one report's content |
 
 Authentication ([API.md → Authentication](API.md#authentication)) differs by tool:
 
-- **`clifton_create_agent` requires OAuth sign-in.** It is not available to API-key callers — the server omits it from their tool list. Creation acts as a specific user, and an org-scoped API key has no user identity.
+- **`clifton_create_agent` accepts OAuth and approved API-key callers.** OAuth callers default to the signed-in user. API-key callers see the tool only when Clifton has enabled API-key creation for their organization; they must pass an `owner_email` for a manager in that organization.
+- **`clifton_delete_agent` requires OAuth sign-in.** The server omits it from API-key tool lists because deletion acts as the signed-in user.
 - **The three read tools accept either** OAuth or an `X-API-Key` header.
 
 The public schemas are listed at `https://ai.cliftonapi.com/.well-known/mcp-tools.json`. Authenticated `tools/list` applies user and organization gates and is authoritative for the caller. If your host does not show these tools, reconnect the Clifton connection. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#your-host-shows-fewer-or-older-clifton-tools-than-expected-or-rejects-a-tool-argument).
@@ -66,7 +68,7 @@ Optional. If you omit it, Clifton confirms the output type during the preview. S
 
 ### Agent limit
 
-Organizations have a cap on concurrently **enabled** agents. If creation would exceed it, the agent is saved with status `disabled` (the console calls this *paused*) instead, and the response is `status: "error"` with a `workflow_limit_exceeded` block carrying your `limit` and current `active_count`. Pause or delete an agent in the [console](https://console.cliftonapi.com), then resume the new one — nothing is lost.
+Organizations have a cap on concurrently **enabled** agents. If creation would exceed it, the agent is saved with status `disabled` (the console calls this *paused*) instead, and the response is `status: "error"` with a `workflow_limit_exceeded` block carrying your `limit` and current `active_count`. Pause an agent in the [console](https://console.cliftonapi.com) or delete one with `clifton_delete_agent`, then resume the new one.
 
 ### Timeouts
 
@@ -75,6 +77,19 @@ Creation turns are slower than `clifton_ask` — the commit turn generates and v
 ### Attachments
 
 File attachments from the MCP host are **not** supported. The `attachments` field accepts Clifton Data Vault file IDs only: files already uploaded via the console. Use `clifton_list_vault_files` to find IDs for files the signed-in user can access, then pass those IDs to `clifton_create_agent.attachments` for agent creation or `clifton_ask.attachments` for one-off analysis.
+
+---
+
+## Deleting an agent
+
+`clifton_delete_agent` accepts one `agent_id`. Use `clifton_list_agents` first when the user names an agent but does not provide its id.
+
+- Call deletion only after the user clearly asks to delete or remove the agent.
+- If several agents match the request, show the matches and ask the user to choose. Do not guess.
+- Do not interpret requests to pause an agent or stop notifications as deletion.
+- Deletion stops future runs and cannot be undone. Existing reports remain available through the report tools.
+
+The tool returns the deleted `agent_id`, `status: "deleted"`, and `reports_retained: true`.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -162,16 +162,17 @@ OAuth callers default to the signed-in user. API-key callers must pass an `owner
 
 ### Agent tools
 
-Four tools for creating and reading Clifton agents (standing monitors that generate reports when their condition fires). Full guide with examples, the agent limit, `output_mode`, and `owner_email` semantics: [AGENT-TOOLS.md](AGENT-TOOLS.md).
+Five tools for creating, deleting, and reading Clifton agents (standing monitors that generate reports when their condition fires). Full guide with examples, deletion behavior, the agent limit, `output_mode`, and `owner_email` semantics: [AGENT-TOOLS.md](AGENT-TOOLS.md).
 
 | Tool | Summary | Key input fields |
 |---|---|---|
-| `clifton_create_agent` | Multi-turn agent creation; commits on your confirmation. **OAuth only** — not offered to API-key callers | `message` (required), `session_id`, `output_mode` (`chat` \| `models`) |
+| `clifton_create_agent` | Multi-turn agent creation; commits on your confirmation. API-key access requires an organization gate and an authorized `owner_email` | `message` (required), `session_id`, `output_mode` (`chat` \| `models`), `owner_email`* |
+| `clifton_delete_agent` | Delete one agent owned by the signed-in user. Existing reports remain available. **OAuth only** | `agent_id` (required) |
 | `clifton_list_agents` | List agents, newest first | `owner_email`*, `limit` (default 10), `offset` |
 | `clifton_list_agent_reports` | List report summaries, newest first | `owner_email`*, `agent_id`, `limit` (default 10), `offset` |
 | `clifton_get_agent_report` | One report: markdown (chat), spreadsheet link (models), or a no-report `reason` | report id, `owner_email`* |
 
-\* `owner_email` defaults to the signed-in user for OAuth callers; required for API-key callers and must belong to the key's organization. Cross-organization reads are rejected.
+\* `owner_email` defaults to the signed-in user for OAuth callers. Read tools require it for API-key callers and reject cross-organization access. `clifton_create_agent` accepts API-key callers only when Clifton has enabled that organization and the selected owner is an authorized manager.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -167,12 +167,12 @@ Five tools for creating, deleting, and reading Clifton agents (standing monitors
 | Tool | Summary | Key input fields |
 |---|---|---|
 | `clifton_create_agent` | Multi-turn agent creation; commits on your confirmation. API-key access requires an organization gate and an authorized `owner_email` | `message` (required), `session_id`, `output_mode` (`chat` \| `models`), `owner_email`* |
-| `clifton_delete_agent` | Delete one agent owned by the signed-in user. Existing reports remain available. **OAuth only** | `agent_id` (required) |
+| `clifton_delete_agent` | Delete one agent owned by an authorized user. Existing reports remain available | `agent_id` (required), `owner_email`* |
 | `clifton_list_agents` | List agents, newest first | `owner_email`*, `limit` (default 10), `offset` |
 | `clifton_list_agent_reports` | List report summaries, newest first | `owner_email`*, `agent_id`, `limit` (default 10), `offset` |
 | `clifton_get_agent_report` | One report: markdown (chat), spreadsheet link (models), or a no-report `reason` | report id, `owner_email`* |
 
-\* `owner_email` defaults to the signed-in user for OAuth callers. Read tools require it for API-key callers and reject cross-organization access. `clifton_create_agent` accepts API-key callers only when Clifton has enabled that organization and the selected owner is an authorized manager.
+\* `owner_email` defaults to the signed-in user for OAuth callers. API-key callers must provide an authorized manager email in the key's organization. `clifton_create_agent` also requires Clifton to enable API-key creation for that organization.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Public changes to the Clifton MCP tool surface.
 ## [Unreleased]
 
 - **Data Vault file discovery.** OAuth and API-key callers can use `clifton_list_vault_files` to find authorized Clifton Data Vault file IDs, then pass those IDs to `clifton_ask.attachments`.
-- **Delete agents through MCP.** `clifton_delete_agent` lets a signed-in user delete one of their agents by id. Deletion stops future runs, cannot be undone, and retains existing reports. API-key callers do not receive the tool.
+- **Delete agents through MCP.** `clifton_delete_agent` lets OAuth and API-key callers delete an authorized owner's agent by id. Deletion stops future runs, cannot be undone, and retains existing reports.
 - **Document gated API-key creation.** The agent guide now reflects the API-key `clifton_create_agent` path already supported by the server for approved organizations.
 
 ## [0.1.2] - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Public changes to the Clifton MCP tool surface.
 ## [Unreleased]
 
 - **Data Vault file discovery.** OAuth and API-key callers can use `clifton_list_vault_files` to find authorized Clifton Data Vault file IDs, then pass those IDs to `clifton_ask.attachments`.
+- **Delete agents through MCP.** `clifton_delete_agent` lets a signed-in user delete one of their agents by id. Deletion stops future runs, cannot be undone, and retains existing reports. API-key callers do not receive the tool.
+- **Document gated API-key creation.** The agent guide now reflects the API-key `clifton_create_agent` path already supported by the server for approved organizations.
 
 ## [0.1.2] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Config snippets live in [`examples/`](examples/).
 
 - **`clifton_ask`** — answers markets & finance questions (equities, ETFs, crypto, bonds, options, macro) from filings, earnings transcripts, analyst expectations, market data, and news; returns citations.
 - **`clifton_list_vault_files`:** OAuth and API-key file discovery for Clifton Data Vault. Use returned file IDs in `clifton_ask.attachments`.
-- **Agent tools:** `clifton_create_agent` creates a standing monitor through a short conversation; `clifton_delete_agent` removes one owned by the signed-in user; `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report` read agents and reports. Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
+- **Agent tools:** `clifton_create_agent` creates a standing monitor through a short conversation; `clifton_delete_agent` removes one owned by an authorized user; `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report` read agents and reports. Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
 
 Full tool reference, auth, and errors: [API.md](API.md).
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On first use, Claude Code connects to Clifton over OAuth. No Client ID is requir
 
 > What was NVDA's most recent reported quarterly revenue?
 
-The plugin also adds a [`clifton-research` skill](plugins/clifton-mcp/skills/clifton-research/SKILL.md) that tells Claude Code when to call `clifton_ask`.
+The plugin also adds a [`clifton-research` skill](plugins/clifton-mcp/skills/clifton-research/SKILL.md) that routes finance questions and agent-management requests to the matching Clifton tools.
 
 ### Cursor, Codex, Manual Claude Code
 
@@ -53,7 +53,7 @@ Config snippets live in [`examples/`](examples/).
 
 - **`clifton_ask`** — answers markets & finance questions (equities, ETFs, crypto, bonds, options, macro) from filings, earnings transcripts, analyst expectations, market data, and news; returns citations.
 - **`clifton_list_vault_files`:** OAuth and API-key file discovery for Clifton Data Vault. Use returned file IDs in `clifton_ask.attachments`.
-- **Agent tools** — `clifton_create_agent` creates a standing monitor through a short conversation (written reports or financial models); `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report` read your agents and their reports. Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
+- **Agent tools:** `clifton_create_agent` creates a standing monitor through a short conversation; `clifton_delete_agent` removes one owned by the signed-in user; `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report` read agents and reports. Guide: [AGENT-TOOLS.md](AGENT-TOOLS.md).
 
 Full tool reference, auth, and errors: [API.md](API.md).
 

--- a/plugins/clifton-mcp/skills/clifton-research/SKILL.md
+++ b/plugins/clifton-mcp/skills/clifton-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clifton-research
-description: Use Clifton for any markets or finance question — stocks, ETFs, crypto, bonds, options, macro and economic data, SEC filings, earnings, transcripts, analyst ratings, screening, cross-company comparisons, and uploaded Clifton Data Vault files — and for Clifton agents, when the user wants to create, monitor, watch, alert on, or schedule a standing market monitor, or to list their agents and read agent reports. Calls clifton_ask, clifton_list_vault_files, and the clifton agent tools on the bundled clifton MCP server.
+description: Use Clifton for markets and finance questions about stocks, ETFs, crypto, bonds, options, macro data, SEC filings, earnings, transcripts, analyst ratings, screening, company comparisons, and uploaded Clifton Data Vault files. Use it for Clifton agent requests to create, monitor, watch, alert, schedule, list, delete, or remove a standing market monitor, or read agent reports. Calls clifton_ask, clifton_list_vault_files, and the Clifton agent tools on the bundled clifton MCP server.
 ---
 
 # Clifton Research & Agents
@@ -49,6 +49,8 @@ Clifton agents watch markets, filings, transcripts, and news for a condition and
 - The agent exists only when `status` is `enabled` and an `agent_url` or `workflow_id` is returned. Share the link when present.
 
 **Reading** — when the user asks to list, show, or check their agents, or wants an agent's latest report, use `clifton_list_agents`, `clifton_list_agent_reports`, and `clifton_get_agent_report`.
+
+**Deleting:** Call `clifton_delete_agent` only after the user clearly asks to delete or remove an agent. If the user gives a name instead of an id, call `clifton_list_agents` first. Delete the agent when exactly one result clearly matches the request; if several match, show them and ask the user to choose. Never treat “pause,” “disable,” or “stop notifications” as deletion. Tell the user that deletion stops future runs, cannot be undone, and retains existing reports.
 
 ## Connection
 


### PR DESCRIPTION
## Summary

- Document clifton_delete_agent for OAuth and API-key callers.
- Explain owner_email, retained reports, and the distinction between deletion and pausing an agent.
- Correct clifton_create_agent documentation for its API-key path.

## Production verification

- [cliftonai/src#9713](https://github.com/cliftonai/src/pull/9713) added agent deletion.
- [cliftonai/src#9767](https://github.com/cliftonai/src/pull/9767) added API-key owner authorization.
- Production enables clifton_create_agent and clifton_delete_agent for OAuth and API-key callers.
- A production API-key smoke created a disposable agent and deleted it successfully on July 14, 2026.

## Validation

- Repository manifest and documentation checks passed.
- git diff --check passed.
- No server or runtime configuration changes.